### PR TITLE
clang-tidy: add no-forgotten-usages check

### DIFF
--- a/clang-tools-extra/clang-tidy/misc/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/misc/CMakeLists.txt
@@ -36,6 +36,7 @@ add_clang_library(clangTidyMiscModule
   MisleadingIdentifier.cpp
   MisplacedConstCheck.cpp
   NewDeleteOverloadsCheck.cpp
+  NoForgottenUsagesCheck.cpp
   NoRecursionCheck.cpp
   NonCopyableObjects.cpp
   NonPrivateMemberVariablesInClassesCheck.cpp

--- a/clang-tools-extra/clang-tidy/misc/MiscTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/misc/MiscTidyModule.cpp
@@ -16,6 +16,7 @@
 #include "MisleadingIdentifier.h"
 #include "MisplacedConstCheck.h"
 #include "NewDeleteOverloadsCheck.h"
+#include "NoForgottenUsagesCheck.h"
 #include "NoRecursionCheck.h"
 #include "NonCopyableObjects.h"
 #include "NonPrivateMemberVariablesInClassesCheck.h"
@@ -48,6 +49,8 @@ public:
     CheckFactories.registerCheck<MisplacedConstCheck>("misc-misplaced-const");
     CheckFactories.registerCheck<NewDeleteOverloadsCheck>(
         "misc-new-delete-overloads");
+    CheckFactories.registerCheck<NoForgottenUsagesCheck>(
+        "misc-no-forgotten-usages");
     CheckFactories.registerCheck<NoRecursionCheck>("misc-no-recursion");
     CheckFactories.registerCheck<NonCopyableObjectsCheck>(
         "misc-non-copyable-objects");

--- a/clang-tools-extra/clang-tidy/misc/NoForgottenUsagesCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/NoForgottenUsagesCheck.cpp
@@ -1,0 +1,66 @@
+//===--- NoForgottenUsagesCheck.cpp - clang-tidy --------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "NoForgottenUsagesCheck.h"
+#include "../utils/OptionsUtils.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+#include "clang/ASTMatchers/ASTMatchers.h"
+#include "llvm/ADT/STLExtras.h"
+#include <string>
+
+using namespace clang::ast_matchers;
+
+namespace clang {
+namespace tidy {
+namespace misc {
+
+NoForgottenUsagesCheck::NoForgottenUsagesCheck(StringRef Name,
+                                               ClangTidyContext *Context)
+    : ClangTidyCheck(Name, Context),
+      Classes(utils::options::parseStringList(Options.get("Classes", ""))) {}
+
+void NoForgottenUsagesCheck::registerMatchers(MatchFinder *Finder) {
+  Finder->addMatcher(varDecl(hasAutomaticStorageDuration()).bind("var"), this);
+}
+
+void NoForgottenUsagesCheck::check(const MatchFinder::MatchResult &Result) {
+  const auto *MatchedDecl = Result.Nodes.getNodeAs<VarDecl>("var");
+  // Non local var decls or referenced are skipped
+  if (!MatchedDecl->isLocalVarDecl() || MatchedDecl->isReferenced()) {
+    return;
+  }
+  // Otherwise check our types.
+  const Type *DesurgaredType =
+      MatchedDecl->getType()->getUnqualifiedDesugaredType();
+  const CXXRecordDecl *RecordType = DesurgaredType->getAsCXXRecordDecl();
+  if (RecordType == nullptr) {
+    return;
+  }
+  // This is the qualified name of the class, for templates this ignores
+  // template parameters.
+  const std::string &QualifiedName = RecordType->getQualifiedNameAsString();
+  bool Matches =
+      llvm::any_of(Classes, [&QualifiedName](const StringRef &Class) {
+        return Class == QualifiedName;
+      });
+  if (!Matches) {
+    return;
+  }
+  // Print out our warning
+  diag(MatchedDecl->getLocation(), "variable %0 with type %1 must be used")
+      << MatchedDecl << RecordType;
+}
+
+void NoForgottenUsagesCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
+  Options.store(Opts, "Classes", utils::options::serializeStringList(Classes));
+}
+
+} // namespace misc
+} // namespace tidy
+} // namespace clang

--- a/clang-tools-extra/clang-tidy/misc/NoForgottenUsagesCheck.h
+++ b/clang-tools-extra/clang-tidy/misc/NoForgottenUsagesCheck.h
@@ -1,0 +1,37 @@
+//===--- NoForgottenUsagesCheck.h - clang-tidy ------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_MISC_NOFORGOTTENUSAGESCHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_MISC_NOFORGOTTENUSAGESCHECK_H
+
+#include "../ClangTidyCheck.h"
+
+namespace clang {
+namespace tidy {
+namespace misc {
+
+/// FIXME: Write a short description.
+///
+/// For the user-facing documentation see:
+/// http://clang.llvm.org/extra/clang-tidy/checks/misc/no-forgotten-usages.html
+class NoForgottenUsagesCheck : public ClangTidyCheck {
+public:
+  NoForgottenUsagesCheck(StringRef Name, ClangTidyContext *Context);
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+  void storeOptions(ClangTidyOptions::OptionMap &Opts) override;
+
+private:
+  const std::vector<StringRef> Classes;
+};
+
+} // namespace misc
+} // namespace tidy
+} // namespace clang
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_MISC_NOFORGOTTENUSAGESCHECK_H

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -115,6 +115,11 @@ New checks
 
   Warns when using ``do-while`` loops.
 
+- New :doc:`misc-no-forgotten-usages
+  <clang-tidy/checks/misc/no-forgotten-usages>` check.
+
+  Adds the ability to force unused variable usages for specific classes.
+
 New check aliases
 ^^^^^^^^^^^^^^^^^
 

--- a/clang-tools-extra/docs/clang-tidy/checks/list.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/list.rst
@@ -248,6 +248,7 @@ Clang-Tidy Checks
    `misc-misleading-identifier <misc/misleading-identifier.html>`_,
    `misc-misplaced-const <misc/misplaced-const.html>`_,
    `misc-new-delete-overloads <misc/new-delete-overloads.html>`_,
+   `misc-no-forgotten-usages <misc/no-forgotten-usages.html>`_,
    `misc-no-recursion <misc/no-recursion.html>`_,
    `misc-non-copyable-objects <misc/non-copyable-objects.html>`_,
    `misc-non-private-member-variables-in-classes <misc/non-private-member-variables-in-classes.html>`_,

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/no-forgotten-usages.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/no-forgotten-usages.rst
@@ -1,0 +1,29 @@
+.. title:: clang-tidy - misc-no-forgotten-usages
+
+misc-no-forgotten-usages
+========================
+
+Allows enforcing variables for a specific type are used even if clang would not normally warn that they are unused (because for example they cause side effects).
+
+Motivating example:
+
+.. code-block:: cpp
+
+   void release_lock();
+
+   struct units {
+      ~units() {
+        release_lock();
+      }
+   };
+
+   future<units> async_get_lock();
+
+   future<> foo() {
+      auto u = async_get_lock(); // missing co_await!
+     // do something, but you don't have the lock!
+      // u is not marked unused by clang normally
+     // adding an unused variable check for future allows forcing the future to be used somehow
+     // if you really don't need the future you're forced to use std::ignore = future();
+   }
+

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/no-forgotten-usages.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/no-forgotten-usages.cpp
@@ -1,0 +1,47 @@
+// RUN: %check_clang_tidy %s misc-no-forgotten-usages %t -- \
+// RUN:       -config="{CheckOptions: [{key: 'misc-no-forgotten-usages.Classes', value: 'seastar::FakeFuture'}]}"
+
+namespace seastar {
+template<typename T>
+class FakeFuture {
+public:    
+    T get() {
+        return Pending;
+    }
+private:
+    T Pending;
+};
+
+
+} // namespace seastar
+
+namespace ss {
+template<typename T>
+using Future = seastar::FakeFuture<T>;
+} // namespace ss
+
+void releaseUnits();
+struct Units {
+  ~Units() {
+    releaseUnits();
+  }
+};
+ss::Future<Units> acquireUnits();
+
+template<typename T>
+T qux(T Generic) {
+    seastar::FakeFuture<Units> PendingA = acquireUnits();
+    auto PendingB = acquireUnits();
+    // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: variable 'PendingB' with type 'FakeFuture<Units>' must be used [misc-no-forgotten-usages]
+    PendingA.get();
+    return Generic;
+}
+
+int bar(int Num) {
+    ss::Future<Units> PendingA = acquireUnits();
+    ss::Future<Units> PendingB = acquireUnits(); // not used at all, unused variable not fired because of destructor side effect
+    // CHECK-MESSAGES: :[[@LINE-1]]:23: warning: variable 'PendingB' with type 'FakeFuture<Units>' must be used [misc-no-forgotten-usages]
+    auto Num2 = PendingA.get();
+    auto Num3 = qux(Num);
+    return Num * Num3;
+}


### PR DESCRIPTION
This check requires that a variable for specific classes must be used.
